### PR TITLE
Ensure a success on requests

### DIFF
--- a/src/AutomaticSharp/Client.cs
+++ b/src/AutomaticSharp/Client.cs
@@ -72,7 +72,7 @@ namespace AutomaticSharp
             }
 
             var request = new HttpRequestMessage(HttpMethod.Get, path);
-            var result = await _httpClient.SendAsync(request);
+            var result = await _httpClient.EnsureSuccessStatusCode().SendAsync(request);
             var content = await result.Content.ReadAsStringAsync();
 
             return new JsonNetSerializer().Deserialize<T>(content);


### PR DESCRIPTION
If the request fails, like `401 Access Denied` (easy to try with invalid access token), you don't get the error, but instead get an empty result object. Adding EnsureSuccessStatusCode() forces a throw if the Http request code indicates a request error.
It took me quite a while trying to figure out why I got empty results, but finally realized that because errors aren't thrown, I didn't realize my access token was invalid.