### PR TITLE
Logical error. Check should be reversed.

### DIFF
--- a/src/AutomaticSharp/Requests/TripsRequest.cs
+++ b/src/AutomaticSharp/Requests/TripsRequest.cs
@@ -53,7 +53,7 @@ namespace AutomaticSharp.Requests
             if (EndedAfter.HasValue)
                 parameters.Add("ended_at__gte", (EndedAfter.Value.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
 
-            if (string.IsNullOrEmpty(VehicleId))
+            if (!string.IsNullOrEmpty(VehicleId))
                 parameters.Add("vehicle", VehicleId);
 
             if (Tags != null && Tags.Any())


### PR DESCRIPTION
Only include vehicle ID if there is one, not the other way around.