### PR TITLE
Fixed parameters query incorrectly being sent

### DIFF
--- a/src/AutomaticSharp/Client.cs
+++ b/src/AutomaticSharp/Client.cs
@@ -63,15 +63,12 @@ namespace AutomaticSharp
         {
             var path = resource;
 
-            if (parameters != null)
+            var request = new HttpRequestMessage(HttpMethod.Get, path);
+            if (parameters != null && parameters.Count > 0)
             {
-                var query = new FormUrlEncodedContent(parameters).ToString();
-
-                if (string.IsNullOrEmpty(query))
-                    path += "?" + query;
+                request.Content = new FormUrlEncodedContent(parameters).ToString();
             }
 
-            var request = new HttpRequestMessage(HttpMethod.Get, path);
             var result = await _httpClient.SendAsync(request);
             var content = await result.Content.ReadAsStringAsync();
 


### PR DESCRIPTION
Calling ToString() on this object just returns the name of the class type, not an actual encoded key/value query string, causing an invalid query string to get generated. Instead all you need to do is set the request content to the object, and the query will automatically be appended to the URI.