### PR TITLE
Correctly append the query string parameters

### DIFF
--- a/src/AutomaticSharp/Client.cs
+++ b/src/AutomaticSharp/Client.cs
@@ -63,12 +63,13 @@ namespace AutomaticSharp
         {
             var path = resource;
 
-            if (parameters != null)
+            if (parameters != null && parameters.Count > 0)
             {
-                var query = new FormUrlEncodedContent(parameters).ToString();
-
-                if (string.IsNullOrEmpty(query))
-                    path += "?" + query;
+                path += "?";
+                foreach(var item in parameters)
+                {
+                    path += $"{item.Key}={Uri.EscapeDataString(item.Value)}&";
+                }
             }
 
             var request = new HttpRequestMessage(HttpMethod.Get, path);


### PR DESCRIPTION
Calling .ToString() on the content class just returns the class name, not the actual encoded query string