### PR TITLE
Update trip requests to reflect now-required parameters

### DIFF
--- a/src/AutomaticSharp/Requests/TripsRequest.cs
+++ b/src/AutomaticSharp/Requests/TripsRequest.cs
@@ -8,14 +8,44 @@ namespace AutomaticSharp.Requests
     public class TripsRequest : RequestWithPaging
     {
         /// <summary>
+        /// Gets the recents trips in the past specified duration
+        /// </summary>
+        /// <param name="duration"></param>
+        public TripsRequest(string vehicleId, TimeSpan duration) : 
+            this(vehicleId, DateTime.UtcNow - duration, DateTime.UtcNow)
+        {
+        }
+
+        /// <summary>
+        /// Gets all recent trips since the startedAfter date
+        /// </summary>
+        /// <param name="startedAfter">Starting time of returned trips</param>
+        public TripsRequest(string vehicleId, DateTime startedAfter) :
+            this(vehicleId, startedAfter, DateTime.UtcNow)
+        {
+        }
+
+        /// <summary>
+        /// Gets all recent trips in the specified time duration
+        /// </summary>
+        /// <param name="startedAfter"></param>
+        /// <param name="startedBefore"></param>
+        public TripsRequest(string vehicleId, DateTime startedAfter, DateTime startedBefore)
+        {
+            VehicleId = vehicleId;
+            StartedAfter = startedAfter;
+            StartedBefore = startedBefore;
+        }
+        
+        /// <summary>
         /// Time the trip started on or before
         /// </summary>
-        public DateTime? StartedBefore { get; set; }
+        public DateTime StartedBefore { get; set; }
 
         /// <summary>
         /// Time the trip started on or after
         /// </summary>
-        public DateTime? StartedAfter { get; set; }
+        public DateTime StartedAfter { get; set; }
 
         /// <summary>
         /// Time the trip ended on or before
@@ -41,20 +71,17 @@ namespace AutomaticSharp.Requests
         {
             var parameters = base.CreateParameters();
 
-            if (StartedBefore.HasValue)
-                parameters.Add("started_at__lte", (StartedBefore.Value.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("started_at__lte", (StartedBefore.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString("0", CultureInfo.InvariantCulture));
 
-            if (StartedAfter.HasValue)
-                parameters.Add("started_at__gte", (StartedAfter.Value.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
+            parameters.Add("started_at__gte", (StartedAfter.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString("0", CultureInfo.InvariantCulture));
+
+            parameters.Add("vehicle", VehicleId);
 
             if (EndedBefore.HasValue)
                 parameters.Add("ended_at__lte", (EndedBefore.Value.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
 
             if (EndedAfter.HasValue)
                 parameters.Add("ended_at__gte", (EndedAfter.Value.ToUniversalTime() - new DateTime(1970, 1, 1)).TotalSeconds.ToString(CultureInfo.InvariantCulture));
-
-            if (string.IsNullOrEmpty(VehicleId))
-                parameters.Add("vehicle", VehicleId);
 
             if (Tags != null && Tags.Any())
                 parameters.Add("tags__in", string.Join(",", Tags));

--- a/src/AutomaticSharp/TripsClient.cs
+++ b/src/AutomaticSharp/TripsClient.cs
@@ -27,12 +27,12 @@ namespace AutomaticSharp
         /// </summary>
         /// <param name="tripsRequest"></param>
         /// <returns></returns>
-        public async Task<AutomaticCollection<Trip>> GetTripsAsync(TripsRequest tripsRequest = null)
+        public async Task<AutomaticCollection<Trip>> GetTripsAsync(TripsRequest tripsRequest)
         {
-            const string path = "trip/";
-
             if (tripsRequest == null)
-                return await GetAsync<AutomaticCollection<Trip>>(path);
+                throw new ArgumentNullException(nameof(tripsRequest));
+            
+            const string path = "trip/";
 
             return await GetAsync<AutomaticCollection<Trip>>(path, tripsRequest.CreateParameters());
         }


### PR DESCRIPTION
`started_at__lte`, `started_at__gte` and `vehicle` are now required parameters when requesting a trip. If you don't provide these, you'll get a `401 Unauthorized` error.

Note that this is a recent change to Automatic's REST API, and their documentation hasn't been updated yet (confirmed by support).